### PR TITLE
Update datalogger.ino

### DIFF
--- a/datalogger.ino
+++ b/datalogger.ino
@@ -1,6 +1,6 @@
 /**
- *  I2C interface to SPI for CTC Ecologic EXT
- *  ver 0.8.9
+    I2C interface to SPI for CTC Ecologic EXT
+    ver 0.8.9
 **/
 
 #include <Wire.h>
@@ -45,6 +45,9 @@ volatile uint8_t SETTINGS;
 volatile uint8_t SYSTIME;
 volatile uint8_t HISTORICAL;
 volatile uint8_t CURRENT;
+volatile uint8_t LAST_24H;
+volatile uint8_t ALARMS;
+volatile uint8_t STATUS;
 
 // Counter...
 volatile uint8_t count = 0;
@@ -52,21 +55,19 @@ volatile uint8_t count = 0;
 // Flags for sampling complete / available for transfer
 volatile boolean sample_done = false;
 volatile boolean new_sample_available = false;
-volatile uint8_t sample_send = 0;
+volatile uint8_t sample_send = B01111111;
 
 // Flags for contact with CTC Ecologic EXT
 volatile boolean first_sync = false;
 volatile boolean sync = false;
 
 /*
- I2C-Write from Master
+  I2C-Write from Master
 */
-static void onWireReceive(int numBytes)
+void onWireReceive(int numBytes)
 {
-  if (!sync) {      // If we got this far, we're in sync!
-    SPDR = 0x01;    // Preload with sync message
+  if (!sync)                  // If we got this far, we're in sync!
     sync = true;
-  }
 
   switch (i2c_state) {
     case I2C_IDLE:
@@ -98,7 +99,6 @@ static void onWireReceive(int numBytes)
         i2c_nextcmd[0] = 0xFF;
         sample_done = true;
         count = 0;
-        SPDR = 0xFE;
       }
       i2c_state = I2C_IDLE;
       break;
@@ -121,9 +121,9 @@ static void onWireReceive(int numBytes)
 } // end of I2C-Write from Master
 
 /*
- I2C-Read from Master
+  I2C-Read from Master
 */
-static void onWireRequest()
+void onWireRequest()
 {
   switch (i2c_state) {
     case I2C_REQUEST:                  // register request
@@ -149,7 +149,7 @@ static void onWireRequest()
 } // end of I2C-Read from Master
 
 /*
- SPI ISR
+  SPI ISR
 */
 ISR (SPI_STC_vect)
 {
@@ -160,31 +160,27 @@ ISR (SPI_STC_vect)
 
   // set status report output
   if (!sync)
-    spi_out = 0;                       // Not in sync with I2C master yet
+    spi_out = 0x00;                       // Not in sync with I2C master yet
   else {
     if (!new_sample_available)
-      spi_out = 1;                     // In sync with I2C master, no new sample available
+      spi_out = 0x01;                     // In sync with I2C master, no new sample available
 
     switch (spi_state) {
       case SPI_IDLE:
         switch (spi_in) {
-          case 0xFE:                   // No-op / PING to I2C master
+          case 0xFF:                   // NO-OP / PING
             break;
 
-          case 0xFF:                   // Start sample sequence from I2C master
-            //            i2c_state = I2C_SAMPLE;
-            break;
-
-          case 0x02:                   // Start command sequence to I2C master
+          case 0xF1:                   // Start command sequence to I2C master
             spi_state = SPI_COMMAND;
-            spi_out = 2;
+            spi_out = 0xF1;
             break;
 
-          case 0x04:                   // Start transferring array
+          case 0xF0:                   // Start transferring array
             if (!new_sample_available)
               break;
             spi_state = SPI_DUMP;
-            spi_out = 4;
+            spi_out = 0xF0;
             break;
         }
         break;
@@ -200,19 +196,23 @@ ISR (SPI_STC_vect)
         spi_state = SPI_IDLE;
         break;
 
-      case SPI_DUMP:                   // Transfer the blocks which has changed
-        if (spi_in == 0xFE)
+      case SPI_DUMP:                   // Routine for transferring data
+        if (spi_in == 0xFF)            // NO-OP / PING
+          break;
+        if (spi_in == 0xFE)            // Signal which blocks has changed
         {
           spi_out = sample_send;
           break;
         }
-        spi_out = datalog[spi_in];
-        if (spi_in == 0xAD)           // Changed to 0xAD in ver 0.8.4, only send up to CURRENT
+        if (spi_in >= 0xAD)           // Changed to 0xAD in ver 0.8.4, only send up to CURRENT
         {
           sample_send = 0;
           new_sample_available = false;
           spi_state = SPI_IDLE;
+          break;
         }
+        else
+          spi_out = datalog[spi_in];
         break;
     }
   }
@@ -247,6 +247,9 @@ void setup()
   SYSTIME = EEPROM.read(2);
   HISTORICAL = EEPROM.read(3);
   CURRENT = EEPROM.read(4);
+  ALARMS = EEPROM.read(5);
+  LAST_24H = EEPROM.read(6);
+  STATUS = EEPROM.read(7);
 
   // Declare arrays to store samples in, no error checking... I KNOW...
   datalog = static_cast<uint8_t*>(calloc(ARRAY_SIZE, sizeof(uint8_t)));
@@ -295,16 +298,31 @@ void loop()
   if (sample_done && i2c_state == I2C_IDLE)
   {
     // Check for change in SYSTIME, normal every minute
-    checkforchange(0x73 , SYSTIME , B00000001);
+    checkforchange(0x73 , 0x75 , B00000001);
 
     // Check for change in CURRENT, normal every change of temp
-    checkforchange(0x8C , CURRENT , B00000010);
+    checkforchange(0x8C , 0x99 , B00000010);
+    checkforchange(0x9B , 0xA0 , B00000010);
+    checkforchange(0xA8 , 0xAC , B00000010);
 
     // Check for change in HISTORICAL, normal every hour and week
-    checkforchange(0x76 , HISTORICAL , B00000100);
+    checkforchange(0x76 , 0x7E , B00000100);
+    checkforchange(0x80 , 0x84 , B00000100);
+    checkforchange(0x87 , 0x8B , B00000100);
 
     // Check for change in SETTINGS, hardly ever any changes
-    checkforchange(0x00 , SETTINGS , B00001000);
+    checkforchange(0x00 , 0x68 , B00001000);
+
+    // Check for change in ALARMS, almost never ever any changes
+    checkforchange(0xA1 , 0xA4 , B00010000);
+
+    // Check for change in LAST_24H,  normal change once every hour
+    checkforchange(0x85 , 0x86 , B00100000);
+    checkforchange(0x7F , 0x7F , B00100000);
+
+    // Check for change in STATUS, normal change every minute
+    checkforchange(0x9A , 0x9A , B01000000);
+    checkforchange(0xA5 , 0xA7 , B01000000);
 
     i2c_state = I2C_SAMPLE;   // Go for another auto sample!
   }


### PR DESCRIPTION
Altered the way we check in what area the samples has changed, due to problems using array containing a sample_template
There will NOT be a multidimensional array, that line of thinking is not viable
Evolution right now is towards sampling ALL available values and then signal in which registered area the changes has occured
Changed sample_send to signal a need to fetch ALL values after a RESET, even those which is 0...(ALARMS)
