### PR TITLE
Update datalogger.ino

### DIFF
--- a/datalogger.ino
+++ b/datalogger.ino
@@ -163,7 +163,6 @@ void onWireReceive(int numBytes)
 
     default:
       test2 |= 64;
-      i2c_state = I2C_IDLE;
   }
 } // end of I2C-Write from Master
 


### PR DESCRIPTION
If we somehow end up in the default, it means i2c_state is either I2C_COMMAND or I2C_REQUEST and if we change state to I2C_IDLE then we will end up in default in the next ISR also...
This is a test what happens if we don't change the state, hopefully it will work
